### PR TITLE
module/alicloud_polardb_cluster: support attributes db_node_id,hot_replica_mode,default_time_zone,lower_case_table_names,db_node_num,loose_polar_log_bin,target_db_revision_version_code,planned_end_time,planned_start_time,from_time_service,upgrade_type; module/alicloud_polardb_cluster_endpoint: support new resource.

### DIFF
--- a/README-CN.md
+++ b/README-CN.md
@@ -22,48 +22,89 @@ terraform-alicloud-polardb-mysql
 
 ```hcl
 module "example" {
-  source                        = "terraform-alicloud-modules/polardb-mysql/alicloud"
+  source = "terraform-alicloud-modules/polardb-mysql/alicloud"
   #alicloud_polardb_cluster
-  create_cluster                = true
-  db_version                    = "8.0" 
-  pay_type                      = "PostPaid"
-  db_node_class                 = "polar.mysql.x4.medium"
-  polardb_cluster_description   = "tf-test"
-  modify_type                   = "Upgrade"
-  renewal_status                = "Normal"
-  tde_status                    = "Disabled"
-  parameters                    = {
-    name = "wait_timeout"
-    value = "86"
-  }
+  create_cluster              = true
+  db_version                  = "8.0"
+  pay_type                    = "PostPaid"
+  db_node_class               = "polar.mysql.x4.medium"
+  polardb_cluster_description = "tf-test"
+  modify_type                 = "Upgrade"
+  renewal_status              = "Normal"
+  tde_status                  = "Disabled"
+  parameters = [
+    {
+      name  = "wait_timeout"
+      value = "86"
+    }
+  ]
+  target_db_revision_version_code = "20240314"
+  db_node_id                      = "1"
+  hot_replica_mode                = "ON"
+  default_time_zone               = "-4:00"
+  lower_case_table_names          = 1
+  db_node_num                     = 1
+  loose_polar_log_bin             = "ON"
+  planned_end_time                = "2024-04-12T13:50:00Z"
+  planned_start_time              = "2024-04-12T14:10:00Z"
+  from_time_service               = "false"
+  upgrade_type                    = "ALL"
   #alicloud_polardb_database
-  create_database               = true
-  db_name                       = "tf-dbname"
+  create_database = true
+  db_name         = "tf-dbname"
   #alicloud_polardb_account
-  create_account                = true
-  account_name                  = "tf_test123" 
-  account_password              = "tf_test123"
-  account_type                  = "Normal"
+  create_account   = true
+  account_name     = "tf_test123"
+  account_password = "tf_test123"
+  account_type     = "Normal"
   #alicloud_polardb_endpoint
-  create_endpoint               = true
-  endpoint_type                 = "Custom"
-  read_write_mode               = "ReadOnly"
-  auto_add_new_nodes            = "Enable"
-  net_type                      = "Public"
+  create_endpoint    = true
+  endpoint_type      = "Custom"
+  read_write_mode    = "ReadOnly"
+  auto_add_new_nodes = "Enable"
+  net_type           = "Public"
   #alicloud_polardb_endpoint_address
-  create_endpoint_address       = true
-  connection_prefix             = "testpolardbconn"
-  account_privilege             = "ReadOnly"
+  create_endpoint_address = true
+  connection_prefix       = "testpolardbconn"
+  account_privilege       = "ReadOnly"
   #alicloud_polardb_account_privilege
-  create_account_privilege      = true
+  create_account_privilege = true
   #alicloud_polardb_backup_policy
-  create_backup_policy          = true
+  create_backup_policy                        = true
+  preferred_backup_period                     = ["Tuesday", "Saturday"]
+  preferred_backup_time                       = "02:00Z-03:00Z"
+  data_level1_backup_retention_period         = "7"
+  data_level2_backup_retention_period         = "60"
+  backup_retention_policy_on_cluster_deletion = "LATEST"
+  backup_frequency                            = "Normal"
+  data_level1_backup_frequency                = "Normal"
+  data_level1_backup_time                     = "02:00Z-03:00Z"
+  data_level1_backup_period                   = ["Tuesday", "Saturday"]
+  data_level2_backup_period                   = ["Tuesday", "Saturday"]
+  log_backup_retention_period                 = "7"
+  #alicloud_polardb_cluster_endpoint
+  create_cluster_endpoint             = true
+  cluster_private_connection_prefix   = "polardbmysqlprivateprefix"
+  cluster_endpoint_private_port       = "5432"
+  db_endpoint_description             = "test_cluster_endpoint"
+  cluster_endpoint_nodes              = []
+  cluster_endpoint_read_write_mode    = "ReadWrite"
+  cluster_endpoint_auto_add_new_nodes = "Enable"
+  cluster_endpoint_config             = {}
+  cluster_endpoint_ssl_enabled        = "Disable"
+  cluster_endpoint_net_type           = "Private"
+  cluster_endpoint_ssl_auto_rotate    = "Disable"
+  #alicloud_polardb_cluster_endpoint_address
+  create_cluster_endpoint_address  = true
+  cluster_public_connection_prefix = "polardbmysqlpublicprefix"
+  cluster_endpoint_public_port     = "3999"
 }
 ```
 
 ## 示例
 
-* [Clickhouse 完整示例](https://github.com/terraform-alicloud-modules/terraform-alicloud-polardb-mysql/tree/main/examples/complete)
+* [PolarDB 完整示例](https://github.com/terraform-alicloud-modules/terraform-alicloud-polardb-mysql/tree/main/examples/complete)
+* [集群地址变更 示例](https://github.com/terraform-alicloud-modules/terraform-alicloud-polardb-mysql/tree/main/examples/cluster-endpoint)
 
 ## 注意事项
 

--- a/README.md
+++ b/README.md
@@ -22,44 +22,55 @@ These types of resources are supported:
 
 ```hcl
 module "example" {
-  source                        = "terraform-alicloud-modules/polardb-mysql/alicloud"
+  source = "terraform-alicloud-modules/polardb-mysql/alicloud"
   #alicloud_polardb_cluster
-  create_cluster                = true
-  db_version                    = "8.0" 
-  pay_type                      = "PostPaid"
-  db_node_class                 = "polar.mysql.x4.medium"
-  polardb_cluster_description   = "tf-test"
-  modify_type                   = "Upgrade"
-  renewal_status                = "Normal"
-  tde_status                    = "Disabled"
+  create_cluster              = true
+  db_version                  = "8.0"
+  pay_type                    = "PostPaid"
+  db_node_class               = "polar.mysql.x4.medium"
+  polardb_cluster_description = "tf-test"
+  modify_type                 = "Upgrade"
+  renewal_status              = "Normal"
+  tde_status                  = "Disabled"
   parameters = [
     {
       name  = "wait_timeout"
       value = "86"
     }
   ]
+  target_db_revision_version_code = "20240314"
+  db_node_id                      = "1"
+  hot_replica_mode                = "ON"
+  default_time_zone               = "-4:00"
+  lower_case_table_names          = 1
+  db_node_num                     = 1
+  loose_polar_log_bin             = "ON"
+  planned_end_time                = "2024-04-12T13:50:00Z"
+  planned_start_time              = "2024-04-12T14:10:00Z"
+  from_time_service               = "false"
+  upgrade_type                    = "ALL"
   #alicloud_polardb_database
-  create_database               = true
-  db_name                       = "tf-dbname"
+  create_database = true
+  db_name         = "tf-dbname"
   #alicloud_polardb_account
-  create_account                = true
-  account_name                  = "tf_test123" 
-  account_password              = "tf_test123"
-  account_type                  = "Normal"
+  create_account   = true
+  account_name     = "tf_test123"
+  account_password = "tf_test123"
+  account_type     = "Normal"
   #alicloud_polardb_endpoint
-  create_endpoint               = true
-  endpoint_type                 = "Custom"
-  read_write_mode               = "ReadOnly"
-  auto_add_new_nodes            = "Enable"
-  net_type                      = "Public"
+  create_endpoint    = true
+  endpoint_type      = "Custom"
+  read_write_mode    = "ReadOnly"
+  auto_add_new_nodes = "Enable"
+  net_type           = "Public"
   #alicloud_polardb_endpoint_address
-  create_endpoint_address       = true
-  connection_prefix             = "testpolardbconn"
-  account_privilege             = "ReadOnly"
+  create_endpoint_address = true
+  connection_prefix       = "testpolardbconn"
+  account_privilege       = "ReadOnly"
   #alicloud_polardb_account_privilege
-  create_account_privilege      = true
+  create_account_privilege = true
   #alicloud_polardb_backup_policy
-  create_backup_policy          = true
+  create_backup_policy                        = true
   preferred_backup_period                     = ["Tuesday", "Saturday"]
   preferred_backup_time                       = "02:00Z-03:00Z"
   data_level1_backup_retention_period         = "7"
@@ -71,13 +82,29 @@ module "example" {
   data_level1_backup_period                   = ["Tuesday", "Saturday"]
   data_level2_backup_period                   = ["Tuesday", "Saturday"]
   log_backup_retention_period                 = "7"
+  #alicloud_polardb_cluster_endpoint
+  create_cluster_endpoint             = true
+  cluster_private_connection_prefix   = "polardbmysqlprivateprefix"
+  cluster_endpoint_private_port       = "5432"
+  db_endpoint_description             = "test_cluster_endpoint"
+  cluster_endpoint_nodes              = []
+  cluster_endpoint_read_write_mode    = "ReadWrite"
+  cluster_endpoint_auto_add_new_nodes = "Enable"
+  cluster_endpoint_config             = {}
+  cluster_endpoint_ssl_enabled        = "Disable"
+  cluster_endpoint_net_type           = "Private"
+  cluster_endpoint_ssl_auto_rotate    = "Disable"
+  #alicloud_polardb_cluster_endpoint_address
+  create_cluster_endpoint_address  = true
+  cluster_public_connection_prefix = "polardbmysqlpublicprefix"
+  cluster_endpoint_public_port     = "3999"
 }
 ```
 
 ## Examples
 
 * [complete example](https://github.com/terraform-alicloud-modules/terraform-alicloud-polardb-mysql/tree/main/examples/complete)
-
+* [cluster-endpoint example](https://github.com/terraform-alicloud-modules/terraform-alicloud-polardb-mysql/tree/main/examples/cluster-endpoint)
 ## Notes
 
 * This module using AccessKey and SecretKey are from `profile` and `shared_credentials_file`. If you have not set them

--- a/examples/cluster-endpoint/README.md
+++ b/examples/cluster-endpoint/README.md
@@ -1,0 +1,23 @@
+# Cluster-endpoint
+
+Configuration in this directory to create cluster_endpoint related services for Polardb MySQL under Alibaba Cloud VPC and VSwitch.
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which cost money. Run `terraform destroy` when you don't need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | > = 0.13.0 |
+| <a name="requirement_alicloud"></a> [alicloud](#requirement\_alicloud) | > = 1.130.1 |

--- a/examples/cluster-endpoint/main.tf
+++ b/examples/cluster-endpoint/main.tf
@@ -1,0 +1,58 @@
+data "alicloud_polardb_node_classes" "default" {
+  db_type    = "MySQL"
+  db_version = "8.0"
+  pay_type   = "PostPaid"
+}
+resource "alicloud_vpc" "default" {
+  vpc_name   = "terraform-example"
+  cidr_block = "172.16.0.0/16"
+}
+
+resource "alicloud_vswitch" "default" {
+  vpc_id       = alicloud_vpc.default.id
+  cidr_block   = "172.16.0.0/24"
+  zone_id      = data.alicloud_polardb_node_classes.default.classes[0].zone_id
+  vswitch_name = "terraform-example"
+}
+
+resource "random_integer" "default" {
+  min = 10000
+  max = 99999
+}
+
+module "default" {
+  source = "../.."
+  #alicloud_polardb_cluster
+  create_cluster              = true
+  db_version                  = "8.0"
+  pay_type                    = "PostPaid"
+  vswitch_id                  = alicloud_vswitch.default.id
+  db_node_class               = var.db_node_class
+  polardb_cluster_description = var.polardb_cluster_description
+  modify_type                 = var.modify_type
+  db_node_count               = var.db_node_count
+  renewal_status              = var.renewal_status
+  auto_renew_period           = var.auto_renew_period
+  period                      = var.period
+  security_ips                = var.security_ips
+  maintain_time               = var.maintain_time
+  collector_status            = var.collector_status
+
+  #alicloud_polardb_cluster_endpoint
+  create_cluster_endpoint             = true
+  cluster_private_connection_prefix   = "polardbmysqlprivateprefix${random_integer.default.result}"
+  cluster_endpoint_private_port       = "5432"
+  db_endpoint_description             = var.db_endpoint_description
+  cluster_endpoint_nodes              = var.cluster_endpoint_nodes
+  cluster_endpoint_read_write_mode    = var.cluster_endpoint_read_write_mode
+  cluster_endpoint_auto_add_new_nodes = var.cluster_endpoint_auto_add_new_nodes
+  cluster_endpoint_config             = var.cluster_endpoint_config
+  cluster_endpoint_ssl_enabled        = "Enable"
+  cluster_endpoint_net_type           = var.cluster_endpoint_net_type
+  cluster_endpoint_ssl_auto_rotate    = var.cluster_endpoint_ssl_auto_rotate
+
+  #alicloud_polardb_cluster_endpoint_address
+  create_cluster_endpoint_address  = true
+  cluster_public_connection_prefix = "polardbmysqlpublicprefix${random_integer.default.result}"
+  cluster_endpoint_public_port     = "3999"
+}

--- a/examples/cluster-endpoint/outputs.tf
+++ b/examples/cluster-endpoint/outputs.tf
@@ -1,0 +1,45 @@
+output "cluster_endpoint_id" {
+  description = "The current instance connection resource ID. Composed of instance ID and connection string with format."
+  value       = module.default.cluster_endpoint_id
+}
+
+output "cluster_endpoint_ssl_connection_string" {
+  description = "The SSL connection string."
+  value       = module.default.cluster_endpoint_ssl_connection_string
+}
+
+output "cluster_endpoint_type" {
+  description = "Type of endpoint."
+  value       = module.default.cluster_endpoint_type
+}
+output "cluster_db_endpoint_id" {
+  description = "Type of endpoint."
+  value       = module.default.cluster_endpoint_db_endpoint_id
+}
+output "cluster_ssl_certificate_url" {
+  description = "Type of endpoint."
+  value       = module.default.cluster_endpoint_ssl_certificate_url
+}
+output "cluster_ssl_expire_time" {
+  description = "Type of endpoint."
+  value       = module.default.cluster_endpoint_ssl_expire_time
+}
+output "cluster_endpoint_address_id" {
+  description = "The id of the polardb endpoint address."
+  value       = module.default.cluster_endpoint_address_id
+}
+
+output "cluster_endpoint_address_port" {
+  description = "Connection cluster or endpoint port."
+  value       = module.default.cluster_endpoint_address_port
+}
+
+output "cluster_endpoint_address_connection_string" {
+  description = "Connection cluster or endpoint string."
+  value       = module.default.cluster_endpoint_address_connection_string
+}
+
+output "cluster_endpoint_address_ip_address" {
+  description = "The ip address of connection string."
+  value       = module.default.cluster_endpoint_address_ip_address
+}

--- a/examples/cluster-endpoint/variables.tf
+++ b/examples/cluster-endpoint/variables.tf
@@ -1,0 +1,140 @@
+#alicloud_polardb_cluster
+variable "db_node_class" {
+  description = "The db_node_class of cluster node."
+  type        = string
+  default     = "polar.mysql.x4.medium"
+}
+
+variable "polardb_cluster_description" {
+  description = "The description of cluster."
+  type        = string
+  default     = "cluster_endpoint_test"
+}
+
+variable "modify_type" {
+  description = "Use as db_node_class change class, define upgrade or downgrade. Valid values are Upgrade, Downgrade, Default to Upgrade."
+  type        = string
+  default     = "Upgrade"
+}
+
+variable "db_node_count" {
+  description = "Number of the PolarDB cluster nodes, default is 2(Each cluster must contain at least a primary node and a read-only node). Add/remove nodes by modifying this parameter, valid values: [2~16]."
+  type        = number
+  default     = 2
+}
+
+variable "renewal_status" {
+  description = "Valid values are AutoRenewal, Normal, NotRenewal, Default to NotRenewal."
+  type        = string
+  default     = "NotRenewal"
+}
+
+variable "auto_renew_period" {
+  description = "Auto-renewal period of an cluster, in the unit of the month. It is valid when pay_type is PrePaid. Valid value:1, 2, 3, 6, 12, 24, 36, Default to 1."
+  type        = number
+  default     = 1
+}
+
+variable "period" {
+  description = "The duration that you will buy DB cluster (in month). It is valid when pay_type is PrePaid. Valid values: [1~9], 12, 24, 36."
+  type        = number
+  default     = 1
+}
+
+variable "security_ips" {
+  description = "List of IP addresses allowed to access all databases of an cluster."
+  type        = set(string)
+  default     = null
+}
+
+variable "maintain_time" {
+  description = "Maintainable time period format of the instance: HH:MMZ-HH:MMZ (UTC time)"
+  type        = string
+  default     = "16:00Z-17:00Z"
+}
+
+variable "collector_status" {
+  description = "Specifies whether to enable or disable SQL data collector. Valid values are Enable, Disabled."
+  type        = string
+  default     = "Disabled"
+}
+
+variable "parameters" {
+  description = "Set of parameters needs to be set after DB cluster was launched. "
+  type        = list(map(string))
+  default     = []
+}
+
+#alicloud_polardb_cluster_endpoint
+variable "create_cluster_endpoint" {
+  description = "Controls if cluster endpoint should be created"
+  type        = bool
+  default     = false
+}
+variable "cluster_private_connection_prefix" {
+  description = "The Prefix of the specified endpoint."
+  type        = string
+  default     = "polardbprivateprefix"
+}
+variable "cluster_endpoint_private_port" {
+  description = "Port of the specified endpoint. Valid values: 3000 to 5999."
+  type        = string
+  default     = null
+}
+variable "db_endpoint_description" {
+  description = "The name of the endpoint."
+  type        = string
+  default     = ""
+}
+variable "cluster_endpoint_nodes" {
+  description = "Node id list for endpoint configuration. Default is all nodes."
+  type        = set(string)
+  default     = null
+}
+variable "cluster_endpoint_read_write_mode" {
+  description = "Read or write mode. Valid values are ReadWrite, ReadOnly. When creating a new custom endpoint, default to ReadOnly."
+  type        = string
+  default     = "ReadWrite"
+}
+variable "cluster_endpoint_auto_add_new_nodes" {
+  description = "Whether the new node automatically joins the default cluster address. Valid values are Enable, Disable. When creating a new custom endpoint, default to Disable."
+  type        = string
+  default     = "Disable"
+}
+variable "cluster_endpoint_config" {
+  description = "The advanced settings of the endpoint of Apsara PolarDB clusters are in JSON format."
+  type        = map(any)
+  default     = {}
+}
+variable "cluster_endpoint_ssl_enabled" {
+  description = "Specifies how to modify the SSL encryption status. Valid values: Disable, Enable, Update."
+  type        = string
+  default     = "Disable"
+}
+variable "cluster_endpoint_net_type" {
+  description = "The network type of the endpoint address.Valid values: Public, Private, Inner."
+  type        = string
+  default     = "Private"
+}
+variable "cluster_endpoint_ssl_auto_rotate" {
+  description = "Specifies whether automatic rotation of SSL certificates is enabled. Valid values: Enable,Disable."
+  type        = string
+  default     = "Disable"
+}
+
+#alicloud_polardb_cluster_endpoint_address
+variable "create_cluster_endpoint_address" {
+  description = "Controls if cluster endpoint address should be created"
+  type        = bool
+  default     = false
+}
+variable "cluster_public_connection_prefix" {
+  description = "The Prefix of the specified endpoint."
+  type        = string
+  default     = "polardbpublicprefix"
+}
+variable "cluster_endpoint_public_port" {
+  description = "Port of the specified endpoint. Valid values: 3000 to 5999."
+  type        = string
+  default     = null
+}

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -3,7 +3,6 @@ data "alicloud_polardb_node_classes" "default" {
   db_version = "8.0"
   pay_type   = "PostPaid"
 }
-
 resource "alicloud_vpc" "default" {
   vpc_name   = "terraform-example"
   cidr_block = "172.16.0.0/16"
@@ -14,6 +13,10 @@ resource "alicloud_vswitch" "default" {
   cidr_block   = "172.16.0.0/24"
   zone_id      = data.alicloud_polardb_node_classes.default.classes[0].zone_id
   vswitch_name = "terraform-example"
+}
+resource "random_integer" "default" {
+  min = 10000
+  max = 99999
 }
 
 module "default" {
@@ -46,6 +49,17 @@ module "default" {
   tags = {
     Created = "TF"
   }
+  target_db_revision_version_code = var.target_db_revision_version_code
+  db_node_id                      = var.db_node_id
+  hot_replica_mode                = var.hot_replica_mode
+  default_time_zone               = var.default_time_zone
+  lower_case_table_names          = var.lower_case_table_names
+  db_node_num                     = var.db_node_num
+  loose_polar_log_bin             = var.loose_polar_log_bin
+  planned_end_time                = var.planned_end_time
+  planned_start_time              = var.planned_start_time
+  from_time_service               = var.from_time_service
+  upgrade_type                    = var.upgrade_type
   #alicloud_polardb_database
   db_name               = "tf-dbname"
   create_database       = true
@@ -60,18 +74,19 @@ module "default" {
   kms_encryption_context = var.kms_encryption_context
   account_type           = "Normal"
   #alicloud_polardb_endpoint
-  create_endpoint    = true
-  endpoint_type      = var.endpoint_type
-  read_write_mode    = var.read_write_mode
-  nodes              = var.nodes
-  auto_add_new_nodes = var.auto_add_new_nodes
-  endpoint_config    = var.endpoint_config
-  ssl_enabled        = var.ssl_enabled
-  net_type           = var.net_type
-  ssl_auto_rotate    = var.ssl_auto_rotate
+  create_endpoint            = true
+  endpoint_type              = var.endpoint_type
+  read_write_mode            = var.read_write_mode
+  nodes                      = var.nodes
+  auto_add_new_nodes         = var.auto_add_new_nodes
+  endpoint_config            = var.endpoint_config
+  ssl_enabled                = var.ssl_enabled
+  net_type                   = var.net_type
+  ssl_auto_rotate            = var.ssl_auto_rotate
+  endpoint_connection_prefix = "${var.endpoint_connection_prefix}-${random_integer.default.result}"
   #alicloud_polardb_endpoint_address
   create_endpoint_address = true
-  connection_prefix       = var.connection_prefix
+  connection_prefix       = "${var.connection_prefix}-${random_integer.default.result}"
   #alicloud_polardb_account_privilege
   create_account_privilege = true
   account_privilege        = "ReadOnly"
@@ -88,4 +103,83 @@ module "default" {
   data_level1_backup_period                   = var.data_level1_backup_period
   data_level2_backup_period                   = var.data_level2_backup_period
   log_backup_retention_period                 = var.log_backup_retention_period
+}
+
+module "example" {
+  source = "terraform-alicloud-modules/polardb-mysql/alicloud"
+  #alicloud_polardb_cluster
+  create_cluster              = true
+  db_version                  = "8.0"
+  pay_type                    = "PostPaid"
+  db_node_class               = "polar.mysql.x4.medium"
+  polardb_cluster_description = "tf-test"
+  modify_type                 = "Upgrade"
+  renewal_status              = "Normal"
+  tde_status                  = "Disabled"
+  parameters = [
+    {
+      name  = "wait_timeout"
+      value = "86"
+    }
+  ]
+  target_db_revision_version_code = "20240314"
+  db_node_id                      = "1"
+  hot_replica_mode                = "ON"
+  default_time_zone               = "-4:00"
+  lower_case_table_names          = 1
+  db_node_num                     = 1
+  loose_polar_log_bin             = "ON"
+  planned_end_time                = "2024-04-12T13:50:00Z"
+  planned_start_time              = "2024-04-12T14:10:00Z"
+  from_time_service               = "false"
+  upgrade_type                    = "ALL"
+  #alicloud_polardb_database
+  create_database = true
+  db_name         = "tf-dbname"
+  #alicloud_polardb_account
+  create_account   = true
+  account_name     = "tf_test123"
+  account_password = "tf_test123"
+  account_type     = "Normal"
+  #alicloud_polardb_endpoint
+  create_endpoint    = true
+  endpoint_type      = "Custom"
+  read_write_mode    = "ReadOnly"
+  auto_add_new_nodes = "Enable"
+  net_type           = "Public"
+  #alicloud_polardb_endpoint_address
+  create_endpoint_address = true
+  connection_prefix       = "testpolardbconn"
+  account_privilege       = "ReadOnly"
+  #alicloud_polardb_account_privilege
+  create_account_privilege = true
+  #alicloud_polardb_backup_policy
+  create_backup_policy                        = true
+  preferred_backup_period                     = ["Tuesday", "Saturday"]
+  preferred_backup_time                       = "02:00Z-03:00Z"
+  data_level1_backup_retention_period         = "7"
+  data_level2_backup_retention_period         = "60"
+  backup_retention_policy_on_cluster_deletion = "LATEST"
+  backup_frequency                            = "Normal"
+  data_level1_backup_frequency                = "Normal"
+  data_level1_backup_time                     = "02:00Z-03:00Z"
+  data_level1_backup_period                   = ["Tuesday", "Saturday"]
+  data_level2_backup_period                   = ["Tuesday", "Saturday"]
+  log_backup_retention_period                 = "7"
+  #alicloud_polardb_cluster_endpoint
+  create_cluster_endpoint             = true
+  cluster_private_connection_prefix   = "polardbmysqlprivateprefix"
+  cluster_endpoint_private_port       = "5432"
+  db_endpoint_description             = "test_cluster_endpoint"
+  cluster_endpoint_nodes              = []
+  cluster_endpoint_read_write_mode    = "ReadWrite"
+  cluster_endpoint_auto_add_new_nodes = "Enable"
+  cluster_endpoint_config             = {}
+  cluster_endpoint_ssl_enabled        = "Disable"
+  cluster_endpoint_net_type           = "Private"
+  cluster_endpoint_ssl_auto_rotate    = "Disable"
+  #alicloud_polardb_cluster_endpoint_address
+  create_cluster_endpoint_address  = true
+  cluster_public_connection_prefix = "polardbmysqlpublicprefix"
+  cluster_endpoint_public_port     = "3999"
 }

--- a/examples/complete/outputs.tf
+++ b/examples/complete/outputs.tf
@@ -61,7 +61,7 @@ output "account_privilege_id" {
 
 output "backup_policy_retention_period" {
   description = "Cluster backup retention days, Fixed for 7 days, not modified."
-  value       = module.default.backup_policy_retention_period
+  value       = module.default.backup_policy_data_level1_backup_retention_period
 }
 
 output "backup_policy_data_level1_backup_retention_period" {

--- a/examples/complete/tfvars/01-update.tfvars
+++ b/examples/complete/tfvars/01-update.tfvars
@@ -6,36 +6,39 @@ db_node_count               = 3
 renewal_status              = "Normal"
 auto_renew_period           = 2
 period                      = 2
-security_ips                = []
 maintain_time               = "16:00Z-17:00Z"
 collector_status            = "Enable"
 tde_status                  = "Enabled"
 encrypt_new_tables          = null
 security_group_ids          = null
 db_description              = "update Database description"
-deletion_lock               = 1
+deletion_lock               = 0
 parameters = [
   {
     name  = "wait_timeout"
     value = "86"
   }
 ]
+db_node_id             = "1"
+hot_replica_mode       = "ON"
+default_time_zone      = "-4:00"
+lower_case_table_names = 1
+db_node_num            = 1
+loose_polar_log_bin    = "ON"
+#target_db_revision_version_code = "20240314"
+#planned_end_time                = "2024-04-12T13:50:00Z"
+#planned_start_time              = "2024-04-12T14:10:00Z"
+from_time_service = "false"
+upgrade_type      = "ALL"
 #alicloud_polardb_account
 account_password       = "tf_test123456"
 account_description    = "update_tf_account_description"
 kms_encrypted_password = ""
 kms_encryption_context = {}
 #alicloud_polardb_endpoint
-endpoint_type      = "Custom"
-read_write_mode    = "ReadWrite"
-nodes              = []
-auto_add_new_nodes = "Enable"
-endpoint_config    = {}
-ssl_enabled        = "Disable"
-net_type           = "Private"
-ssl_auto_rotate    = "Disable"
+read_write_mode = "ReadWrite"
 #alicloud_polardb_endpoint_address
-connection_prefix = "testpolardbconnprefix"
+connection_prefix = "testpolardbconn"
 #alicloud_polardb_account_privilege
 account_privilege = "ReadOnly"
 #alicloud_polardb_backup_policy

--- a/examples/complete/variables.tf
+++ b/examples/complete/variables.tf
@@ -82,6 +82,62 @@ variable "security_group_ids" {
   type        = set(string)
   default     = null
 }
+variable "target_db_revision_version_code" {
+  description = "The Version Code of the target version, whose parameter values can be obtained from the [DescribeDBClusterVersion] interface."
+  type        = string
+  default     = null
+}
+variable "db_node_id" {
+  description = "The ID of the node or node subscript. Node subscript values: 1 to 15."
+  type        = string
+  default     = null
+}
+variable "hot_replica_mode" {
+  description = "Indicates whether the hot standby feature is enabled. Valid values are `ON`, `OFF`. Only MySQL supports."
+  type        = string
+  default     = null
+}
+variable "default_time_zone" {
+  description = "The time zone of the cluster. You can set the parameter to a value that is on the hour from -12:00 to +13:00 based on UTC. Example: 00:00. Default value: SYSTEM. This value indicates that the time zone of the cluster is the same as the time zone of the region."
+  type        = string
+  default     = "SYSTEM"
+}
+variable "lower_case_table_names" {
+  description = "Specifies whether the table names are case-sensitive. Default value: `1`.  Valid values are `1`, `0`."
+  type        = number
+  default     = 1
+}
+variable "db_node_num" {
+  description = "The number of Standard Edition nodes. Default value: `1`. Valid values are `1`, `2`."
+  type        = number
+  default     = 1
+}
+variable "loose_polar_log_bin" {
+  description = "Enable the Binlog function. Default value: `OFF`. Valid values are `OFF`, `ON`."
+  type        = string
+  default     = "OFF"
+}
+
+variable "planned_end_time" {
+  description = "The latest time to start executing the target scheduled task. The format is YYYY-MM-DDThh: mm: ssZ (UTC)."
+  type        = string
+  default     = ""
+}
+variable "planned_start_time" {
+  description = "The earliest time to start executing a scheduled (i.e. within the target time period) kernel version upgrade task. The format is YYYY-MM-DDThh: mm: ssZ (UTC)."
+  type        = string
+  default     = ""
+}
+variable "from_time_service" {
+  description = "Immediate or scheduled kernel version upgrade. Valid values are `true`, `false`. True means immediate execution, False means scheduled execution."
+  type        = string
+  default     = "false"
+}
+variable "upgrade_type" {
+  description = "Version upgrade type. Valid values are PROXY, DB, ALL. PROXY means upgrading the proxy version, DB means upgrading the db version, ALL means upgrading both db and proxy versions simultaneously."
+  type        = string
+  default     = "ALL"
+}
 
 #alicloud_polardb_database
 variable "db_description" {
@@ -148,12 +204,17 @@ variable "ssl_enabled" {
 variable "net_type" {
   description = "The network type of the endpoint address.Valid values: Public, Private, Inner."
   type        = string
-  default     = "Public"
+  default     = "Private"
 }
 variable "ssl_auto_rotate" {
   description = "Specifies whether automatic rotation of SSL certificates is enabled. Valid values: Enable,Disable."
   type        = string
   default     = "Disable"
+}
+variable "endpoint_connection_prefix" {
+  description = "The Prefix of the specified endpoint."
+  type        = string
+  default     = "testprivateprefix"
 }
 
 #alicloud_polardb_endpoint_address
@@ -231,13 +292,13 @@ variable "data_level2_backup_period" {
   default     = null
 }
 
-variable "deletion_lock"{
+variable "deletion_lock" {
   description = "Valid values are 0, 1. 1 means to open the cluster protection lock, 0 means to close the cluster protection lock. Cannot modify after created when pay_type is Prepaid."
-  type = number
-  default = null
+  type        = number
+  default     = null
 }
 
-variable "log_backup_retention_period"{
+variable "log_backup_retention_period" {
   description = "The retention period of the log backups. Valid values are `3 to 7300`, `-1`."
   type        = string
   default     = "8"

--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,18 @@ resource "alicloud_polardb_cluster" "cluster" {
       value = lookup(parameters.value, "value", null)
     }
   }
-  tags = var.tags
+  tags                            = var.tags
+  target_db_revision_version_code = var.target_db_revision_version_code
+  db_node_id                      = var.db_node_id
+  hot_replica_mode                = var.hot_replica_mode
+  default_time_zone               = var.default_time_zone
+  lower_case_table_names          = var.lower_case_table_names
+  db_node_num                     = var.db_node_num
+  loose_polar_log_bin             = var.loose_polar_log_bin
+  planned_end_time                = var.planned_end_time
+  planned_start_time              = var.planned_start_time
+  from_time_service               = var.from_time_service
+  upgrade_type                    = var.upgrade_type
 }
 
 resource "alicloud_polardb_database" "database" {
@@ -61,6 +72,7 @@ resource "alicloud_polardb_endpoint" "endpoint" {
   ssl_enabled        = var.ssl_enabled
   net_type           = var.net_type
   ssl_auto_rotate    = var.ssl_auto_rotate
+  connection_prefix  = var.endpoint_connection_prefix
 }
 
 resource "alicloud_polardb_endpoint_address" "endpoint_address" {
@@ -93,4 +105,28 @@ resource "alicloud_polardb_backup_policy" "backup_policy" {
   data_level1_backup_period                   = var.data_level1_backup_period
   data_level2_backup_period                   = var.data_level2_backup_period
   log_backup_retention_period                 = var.log_backup_retention_period
+}
+
+resource "alicloud_polardb_cluster_endpoint" "endpoint" {
+  count                   = var.create_cluster_endpoint ? 1 : 0
+  db_cluster_id           = local.this_db_cluster_id
+  connection_prefix       = var.cluster_private_connection_prefix
+  port                    = var.cluster_endpoint_private_port
+  read_write_mode         = var.cluster_endpoint_read_write_mode
+  nodes                   = var.cluster_endpoint_nodes
+  auto_add_new_nodes      = var.cluster_endpoint_auto_add_new_nodes
+  endpoint_config         = var.cluster_endpoint_config
+  ssl_enabled             = var.cluster_endpoint_ssl_enabled
+  net_type                = var.cluster_endpoint_net_type
+  ssl_auto_rotate         = var.cluster_endpoint_ssl_auto_rotate
+  db_endpoint_description = var.db_endpoint_description
+}
+
+resource "alicloud_polardb_endpoint_address" "cluster_endpoint_address" {
+  count             = var.create_cluster_endpoint_address ? 1 : 0
+  db_cluster_id     = local.this_db_cluster_id
+  db_endpoint_id    = concat(alicloud_polardb_cluster_endpoint.endpoint.*.db_endpoint_id, [""])[0]
+  net_type          = "Public"
+  connection_prefix = var.cluster_public_connection_prefix
+  port              = var.cluster_endpoint_public_port
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -61,7 +61,7 @@ output "account_privilege_id" {
 
 output "backup_policy_retention_period" {
   description = "Cluster backup retention days, Fixed for 7 days, not modified."
-  value       = concat(alicloud_polardb_backup_policy.backup_policy.*.backup_retention_period, [""])[0]
+  value       = concat(alicloud_polardb_backup_policy.backup_policy.*.data_level1_backup_retention_period, [""])[0]
 }
 
 output "backup_policy_data_level1_backup_retention_period" {
@@ -107,4 +107,49 @@ output "backup_policy_data_level2_backup_period" {
 output "backup_policy_log_backup_retention_period" {
   description = "The retention period of the log backups. Valid values are `3 to 7300`, `-1`."
   value       = concat(alicloud_polardb_backup_policy.backup_policy.*.log_backup_retention_period, [""])[0]
+}
+
+output "cluster_endpoint_id" {
+  description = "The current instance connection resource ID. Composed of instance ID and connection string with format."
+  value       = concat(alicloud_polardb_cluster_endpoint.endpoint.*.id, [""])[0]
+}
+
+output "cluster_endpoint_ssl_connection_string" {
+  description = "The SSL connection string."
+  value       = concat(alicloud_polardb_cluster_endpoint.endpoint.*.ssl_connection_string, [""])[0]
+}
+output "cluster_endpoint_type" {
+  description = "Type of endpoint."
+  value       = concat(alicloud_polardb_cluster_endpoint.endpoint.*.endpoint_type, [""])[0]
+}
+output "cluster_endpoint_db_endpoint_id" {
+  description = "The ID of the cluster endpoint."
+  value       = concat(alicloud_polardb_cluster_endpoint.endpoint.*.db_endpoint_id, [""])[0]
+}
+output "cluster_endpoint_ssl_certificate_url" {
+  description = "The specifies SSL certificate download link."
+  value       = concat(alicloud_polardb_cluster_endpoint.endpoint.*.ssl_certificate_url, [""])[0]
+}
+output "cluster_endpoint_ssl_expire_time" {
+  description = "The time when the SSL certificate expires. The time follows the ISO 8601 standard in the yyyy-MM-ddTHH:mm:ssZ format. The time is displayed in UTC."
+  value       = concat(alicloud_polardb_cluster_endpoint.endpoint.*.ssl_expire_time, [""])[0]
+}
+output "cluster_endpoint_address_id" {
+  description = "The id of the polardb endpoint address."
+  value       = concat(alicloud_polardb_endpoint_address.cluster_endpoint_address.*.id, [""])[0]
+}
+
+output "cluster_endpoint_address_port" {
+  description = "Connection cluster or endpoint port."
+  value       = concat(alicloud_polardb_endpoint_address.cluster_endpoint_address.*.port, [""])[0]
+}
+
+output "cluster_endpoint_address_connection_string" {
+  description = "Connection cluster or endpoint string."
+  value       = concat(alicloud_polardb_endpoint_address.cluster_endpoint_address.*.connection_string, [""])[0]
+}
+
+output "cluster_endpoint_address_ip_address" {
+  description = "The ip address of connection string."
+  value       = concat(alicloud_polardb_endpoint_address.cluster_endpoint_address.*.ip_address, [""])[0]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -125,6 +125,62 @@ variable "security_group_ids" {
   default     = null
 }
 
+variable "target_db_revision_version_code" {
+  description = "The Version Code of the target version, whose parameter values can be obtained from the [DescribeDBClusterVersion] interface."
+  type        = string
+  default     = null
+}
+variable "db_node_id" {
+  description = "The ID of the node or node subscript. Node subscript values: 1 to 15."
+  type        = string
+  default     = null
+}
+variable "hot_replica_mode" {
+  description = "Indicates whether the hot standby feature is enabled. Valid values are `ON`, `OFF`. Only MySQL supports."
+  type        = string
+  default     = null
+}
+variable "default_time_zone" {
+  description = "The time zone of the cluster. You can set the parameter to a value that is on the hour from -12:00 to +13:00 based on UTC. Example: 00:00. Default value: SYSTEM. This value indicates that the time zone of the cluster is the same as the time zone of the region."
+  type        = string
+  default     = "SYSTEM"
+}
+variable "lower_case_table_names" {
+  description = "Specifies whether the table names are case-sensitive. Default value: `1`.  Valid values are `1`, `0`."
+  type        = number
+  default     = 1
+}
+variable "db_node_num" {
+  description = "The number of Standard Edition nodes. Default value: `1`. Valid values are `1`, `2`."
+  type        = number
+  default     = 1
+}
+variable "loose_polar_log_bin" {
+  description = "Enable the Binlog function. Default value: `OFF`. Valid values are `OFF`, `ON`."
+  type        = string
+  default     = "OFF"
+}
+variable "planned_end_time" {
+  description = "The latest time to start executing the target scheduled task. The format is YYYY-MM-DDThh: mm: ssZ (UTC)."
+  type        = string
+  default     = ""
+}
+variable "planned_start_time" {
+  description = "The earliest time to start executing a scheduled (i.e. within the target time period) kernel version upgrade task. The format is YYYY-MM-DDThh: mm: ssZ (UTC)."
+  type        = string
+  default     = ""
+}
+variable "from_time_service" {
+  description = "Immediate or scheduled kernel version upgrade. Valid values are `true`, `false`. True means immediate execution, False means scheduled execution."
+  type        = string
+  default     = "false"
+}
+variable "upgrade_type" {
+  description = "Version upgrade type. Valid values are PROXY, DB, ALL. PROXY means upgrading the proxy version, DB means upgrading the db version, ALL means upgrading both db and proxy versions simultaneously."
+  type        = string
+  default     = "ALL"
+}
+
 #alicloud_polardb_database
 variable "create_database" {
   description = "Controls if database should be created"
@@ -245,13 +301,18 @@ variable "ssl_enabled" {
 variable "net_type" {
   description = "The network type of the endpoint address.Valid values: Public, Private, Inner."
   type        = string
-  default     = "Public"
+  default     = "Private"
 }
 
 variable "ssl_auto_rotate" {
   description = "Specifies whether automatic rotation of SSL certificates is enabled. Valid values: Enable,Disable."
   type        = string
   default     = "Disable"
+}
+variable "endpoint_connection_prefix" {
+  description = "The Prefix of the specified endpoint."
+  type        = string
+  default     = ""
 }
 
 #alicloud_polardb_endpoint_address
@@ -347,14 +408,88 @@ variable "data_level2_backup_period" {
   default     = null
 }
 
-variable "deletion_lock"{
+variable "deletion_lock" {
   description = "Valid values are 0, 1. 1 means to open the cluster protection lock, 0 means to close the cluster protection lock. Cannot modify after created when pay_type is Prepaid."
-  type = number
-  default = null
+  type        = number
+  default     = null
 }
 
-variable "log_backup_retention_period"{
+variable "log_backup_retention_period" {
   description = "The retention period of the log backups. Valid values are `3 to 7300`, `-1`."
+  type        = string
+  default     = null
+}
+
+#alicloud_polardb_cluster_endpoint
+variable "create_cluster_endpoint" {
+  description = "Controls if cluster endpoint should be created"
+  type        = bool
+  default     = false
+}
+variable "cluster_private_connection_prefix" {
+  description = "The Prefix of the specified endpoint."
+  type        = string
+  default     = ""
+}
+variable "cluster_endpoint_private_port" {
+  description = "Port of the specified endpoint. Valid values: 3000 to 5999."
+  type        = string
+  default     = null
+}
+variable "db_endpoint_description" {
+  description = "The name of the endpoint."
+  type        = string
+  default     = ""
+}
+variable "cluster_endpoint_nodes" {
+  description = "Node id list for endpoint configuration. Default is all nodes."
+  type        = set(string)
+  default     = null
+}
+variable "cluster_endpoint_read_write_mode" {
+  description = "Read or write mode. Valid values are ReadWrite, ReadOnly. When creating a new custom endpoint, default to ReadOnly."
+  type        = string
+  default     = "ReadWrite"
+}
+variable "cluster_endpoint_auto_add_new_nodes" {
+  description = "Whether the new node automatically joins the default cluster address. Valid values are Enable, Disable. When creating a new custom endpoint, default to Disable."
+  type        = string
+  default     = "Disable"
+}
+variable "cluster_endpoint_config" {
+  description = "The advanced settings of the endpoint of Apsara PolarDB clusters are in JSON format."
+  type        = map(any)
+  default     = {}
+}
+variable "cluster_endpoint_ssl_enabled" {
+  description = "Specifies how to modify the SSL encryption status. Valid values: Disable, Enable, Update."
+  type        = string
+  default     = "Disable"
+}
+variable "cluster_endpoint_net_type" {
+  description = "The network type of the endpoint address.Valid values: Public, Private, Inner."
+  type        = string
+  default     = "Private"
+}
+variable "cluster_endpoint_ssl_auto_rotate" {
+  description = "Specifies whether automatic rotation of SSL certificates is enabled. Valid values: Enable,Disable."
+  type        = string
+  default     = "Disable"
+}
+
+#alicloud_polardb_cluster_endpoint_address
+variable "create_cluster_endpoint_address" {
+  description = "Controls if cluster endpoint address should be created"
+  type        = bool
+  default     = false
+}
+variable "cluster_public_connection_prefix" {
+  description = "The Prefix of the specified endpoint."
+  type        = string
+  default     = ""
+}
+variable "cluster_endpoint_public_port" {
+  description = "Port of the specified endpoint. Valid values: 3000 to 5999."
   type        = string
   default     = null
 }


### PR DESCRIPTION
terraform module docking terraform provider parameters, alicloud_polardb_cluster_endpoint and alicloud_polardb_cluster partial parameters.